### PR TITLE
Add logger warning when chunk size added is greater than specified size

### DIFF
--- a/lib/baran/text_splitter.rb
+++ b/lib/baran/text_splitter.rb
@@ -1,3 +1,5 @@
+require 'logger'
+
 module Baran
   class TextSplitter
     attr_accessor :chunk_size, :chunk_overlap
@@ -46,6 +48,7 @@ module Baran
 
         current_splits << split
         total += split.length
+        Logger.new(STDOUT).warn("Created a chunk of size #{total}, which is longer than the specified #{@chunk_size}") if total > @chunk_size
       end
 
       results << joined(current_splits, separator)


### PR DESCRIPTION
It is possible for the `TextSplitter`class to create a chunk that is greater than the specified `chunk_size` so I think it would be a good idea to log a warning when this happens