### PR TITLE
compact chunks on text splitter

### DIFF
--- a/lib/baran/text_splitter.rb
+++ b/lib/baran/text_splitter.rb
@@ -18,7 +18,7 @@ module Baran
       cursor = 0
       chunks = []
 
-      splitted(text).each do |chunk|
+      splitted(text).compact.each do |chunk|
         chunks << { text: chunk, cursor: cursor }
         cursor += chunk.length
       end

--- a/test/test_recursive_character_text_splitter.rb
+++ b/test/test_recursive_character_text_splitter.rb
@@ -13,4 +13,11 @@ class TestRecursiveCharacterTextSplitter < MiniTest::Unit::TestCase
 
     assert_equal(chunks.length, 6)
   end
+
+
+  def test_empty_chunks
+    chunks = @splitter.chunks("\n\nHello, world!\n\nHello, world!\n\nHello, world!")
+
+    assert_equal(chunks.length, 6)
+  end
 end


### PR DESCRIPTION
when the texts have line breaks on the beginning the splitter fails as it adds nil elements

example: 

`"\n\nHello, world!\n\nHello, world!\n\nHello, world!"`