### PR TITLE
Update markdown_splitter.rb

### DIFF
--- a/lib/baran/markdown_splitter.rb
+++ b/lib/baran/markdown_splitter.rb
@@ -3,7 +3,7 @@ require_relative './recursive_character_text_splitter'
 module Baran
   class MarkdownSplitter < RecursiveCharacterTextSplitter
     def initialize(chunk_size: 1024, chunk_overlap: 64)
-      @separators = [
+      separators = [
         "\n# ", # h1
         "\n## ", # h2
         "\n### ", # h3
@@ -19,7 +19,7 @@ module Baran
         " ", # space
         "" # empty
       ]
-      super(chunk_size: chunk_size, chunk_overlap: chunk_overlap)
+      super(chunk_size: chunk_size, chunk_overlap: chunk_overlap, separators: separators)
     end
   end
 end

--- a/test/test_markdown_splitter.rb
+++ b/test/test_markdown_splitter.rb
@@ -9,10 +9,30 @@ class TestMarkdownSplitter < MiniTest::Unit::TestCase
   end
 
   def test_chunks
-    text = "# h1\n\n## h2\n\n### h3\n\n#### h4\n\n##### h5\n\n###### h6\n\n```\n\n```\n\n***\n\n---"
+    text = <<~MARKDOWN
+# h1
+
+## h2
+
+### h3
+
+#### h4
+
+##### h5
+
+###### h6
+
+```
+```
+
+***
+
+---
+MARKDOWN
+
     @splitter = Baran::MarkdownSplitter.new(chunk_size: 3, chunk_overlap: 1)
     chunks = @splitter.chunks(text)
 
-    assert_equal(chunks.length, 30)
+    assert_equal(13, chunks.length)
   end
 end


### PR DESCRIPTION
The inherited class would overwrite the separators

https://github.com/kawakamimoeki/baran/blob/main/lib/baran/recursive_character_text_splitter.rb#L7-L10C7