### PR TITLE
Handles text that does not end in a white space for SentenceTextSpliter

### DIFF
--- a/lib/baran/sentence_text_splitter.rb
+++ b/lib/baran/sentence_text_splitter.rb
@@ -8,7 +8,7 @@ module Baran
 
     def splitted(text)
       # Use a regex to split text based on the specified sentence-ending characters followed by whitespace
-      text.scan(/[^.!?]+[.!?]+(?:\s+)/).map(&:strip)
+      text.scan(/[^.!?]+[.!?]+(?:\s+|\z)/).map(&:strip)
     end
   end
 end

--- a/test/test_sentence_text_spliter.rb
+++ b/test/test_sentence_text_spliter.rb
@@ -6,10 +6,7 @@ MiniTest::Unit.autorun
 class TestSentenceTextSplitter < MiniTest::Unit::TestCase
   def setup
     @splitter = Baran::SentenceTextSplitter.new(chunk_size: 10, chunk_overlap: 5)
-  end
-
-  def test_chunks
-    story = <<~TEXT
+    @story = <<~TEXT
       Hack and jill
         went up the hill to fetch
         a pail of water.  Jack fell
@@ -19,23 +16,36 @@ class TestSentenceTextSplitter < MiniTest::Unit::TestCase
         No, the water was splashed on Bo Peep.
     TEXT
 
-    chunks = @splitter.chunks(story)
-
-    sentences = chunks
-                  .map  { |chunk| 
-                          chunk[:text]
-                            .gsub(/\s+/, ' ')
-                            .strip 
-                        }
-
-    expected  = [
-      "Hack and jill went up the hill to fetch a pail of water.", 
-      "Jack fell down and broke his crown and Jill came tumbling after.", 
-      "The pail went flying!", 
-      "Was the water spilled?", 
+    @expected =[
+      "Hack and jill went up the hill to fetch a pail of water.",
+      "Jack fell down and broke his crown and Jill came tumbling after.",
+      "The pail went flying!",
+      "Was the water spilled?",
       "No, the water was splashed on Bo Peep."
     ]
+  end
 
-    assert_equal(sentences, expected)
+  def test_chunks
+    chunks = @splitter.chunks(@story)
+    sentences = format_chunks(chunks)
+    assert_equal(sentences, @expected)
+  end
+
+  def test_chunks_without_trailing_whitespace
+    chunks = @splitter.chunks(@story.strip)
+    sentences = format_chunks(chunks)
+    assert_equal(sentences, @expected)
+  end
+
+
+  private
+
+  def format_chunks(chunks)
+    chunks
+      .map  { |chunk|
+              chunk[:text]
+                .gsub(/\s+/, ' ')
+                .strip
+            }
   end
 end


### PR DESCRIPTION
This is a suggested minor addition to the regex used for SentenceTextSpliter.

It currently requires whitespace before the ending punctuation. This removes the white space requirement if it is at the end of the string. 